### PR TITLE
Remove sinon from production dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,12 +40,10 @@
   },
   "dependencies": {
     "@iarna/toml": "2.2.5",
-    "@types/sinon": "9.0.10",
     "@voximplant/apiclient-nodejs": "2.0.5",
     "chalk": "4.1.2",
     "commander": "9.0.0",
     "dotenv": "10.0.0",
-    "sinon": "11.1.1",
     "typescript": "4.3.5",
     "yaml": "1.10.2"
   },
@@ -60,6 +58,7 @@
     "@types/mocha": "9.1.0",
     "@types/node": "16.11.0",
     "@types/rewire": "2.5.28",
+    "@types/sinon": "9.0.10",
     "@typescript-eslint/eslint-plugin": "4.29.2",
     "@typescript-eslint/parser": "4.29.2",
     "chai": "4.3.6",
@@ -76,6 +75,7 @@
     "prettier-eslint": "8.2.2",
     "rewire": "5.0.0",
     "semantic-release": "18.0.0",
+    "sinon": "11.1.1",
     "ts-node": "10.2.0"
   },
   "publishConfig": {


### PR DESCRIPTION
My yarn seems to be too new, so it wants to completely remake `yarn.lock` file which is unwanted. I would suggest updating `yarn.lock` on your side in order to prevent a lot of unneeded changes :)